### PR TITLE
Campos personalizados do cadastro geral

### DIFF
--- a/install.xml
+++ b/install.xml
@@ -1,1 +1,210 @@
-<?xml version="1.0" encoding="UTF-8"?><modification>  <name>Exibe os campos personalizados de endereço nos dados do pedido</name>  <code>exibir-campos-personalizados</code>  <version>2.2</version>  <author>Valdeir Psr e Manoel Vidal</author>  <link>http://www.opencartbrasil.com.br</link>  <file path="admin/view/template/customer/custom_field_list.tpl">    <operation>      <search><![CDATA[<td style="width: 1px;" class="text-center"><input type="checkbox" onclick="$('input[name*=\'selected\']').prop('checked', this.checked);" /></td>]]></search>      <add position="after"><![CDATA[                  <td style="width: 1px;" class="text-center">Id</td>	  ]]></add>    </operation>    <operation>      <search><![CDATA[<td class="text-left"><?php echo $custom_field['name']; ?></td>]]></search>      <add position="before"><![CDATA[<td class="text-center"><?php echo $custom_field['custom_field_id']; ?></td>]]></add>    </operation>    <operation>      <search><![CDATA[<td class="text-center" colspan="6"><?php echo $text_no_results; ?></td>]]></search>      <add position="replace"><![CDATA[<td class="text-center" colspan="7"><?php echo $text_no_results; ?></td>]]></add>    </operation>  </file>  <file path="admin/model/localisation/country.php">    <operation>      <search><![CDATA[$this->db->query("UPDATE " . DB_PREFIX . "country SET name = '" . $this->db->escape($data['name']) . "', iso_code_2 = '" . $this->db->escape($data['iso_code_2']) . "', iso_code_3 = '" . $this->db->escape($data['iso_code_3']) . "', address_format = '" . $this->db->escape($data['address_format']) . "', postcode_required = '" . (int)$data['postcode_required'] . "', status = '" . (int)$data['status'] . "' WHERE country_id = '" . (int)$country_id . "'");]]></search>      <add position="after"><![CDATA[        $this->db->query("UPDATE " . DB_PREFIX . "order SET shipping_address_format = '" . $this->db->escape($data['address_format']) . "', payment_address_format = '" . $this->db->escape($data['address_format']) . "'");      ]]></add>    </operation>  </file>  <file path="admin/controller/sale/order.php">    <operation>      <search><![CDATA[$custom_fields = $this->model_customer_custom_field->getCustomFields($filter_data);]]></search>      <add position="replace"><![CDATA[        $custom_fields = $this->model_customer_custom_field->getCustomFields(array('sort' => 'cf.sort_order'));      ]]></add>    </operation>    <operation>      <search><![CDATA[foreach ($orders as $order_id) {]]></search>      <add position="before"><![CDATA[		$this->load->model('customer/custom_field');		$custom_fields = $this->model_customer_custom_field->getCustomFields();      ]]></add>    </operation>    <operation>      <search><![CDATA[$data['payment_address'] = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>      <add position="after"><![CDATA[			$data['payment_address'] = ($order_info['payment_firstname']) ? $data['payment_address'] : '';      ]]></add>    </operation>    <operation>      <search><![CDATA[$data['payment_address'] = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>      <add position="before"><![CDATA[			foreach ($custom_fields as $custom_field) {			  if (isset($order_info['payment_custom_field'][$custom_field['custom_field_id']])){				$format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['payment_custom_field'][$custom_field['custom_field_id']], $format);			  }			}      ]]></add>    </operation>    <operation>      <search><![CDATA[$payment_address = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>      <add position="after"><![CDATA[			$payment_address = ($order_info['payment_firstname']) ? $payment_address : '';      ]]></add>    </operation>    <operation>      <search><![CDATA[$payment_address = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>      <add position="before"><![CDATA[			foreach ($custom_fields as $custom_field) {			  if (isset($order_info['payment_custom_field'][$custom_field['custom_field_id']])){				$format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['payment_custom_field'][$custom_field['custom_field_id']], $format);			  }			}      ]]></add>    </operation>    <operation>      <search><![CDATA[$data['shipping_address'] = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>      <add position="after"><![CDATA[			$data['shipping_address'] = ($order_info['shipping_firstname']) ? $data['shipping_address'] : '';      ]]></add>    </operation>    <operation>      <search><![CDATA[$data['shipping_address'] = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>      <add position="before"><![CDATA[			foreach ($custom_fields as $custom_field) {			  if (isset($order_info['shipping_custom_field'][$custom_field['custom_field_id']])){				$format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['shipping_custom_field'][$custom_field['custom_field_id']], $format);			  }			}      ]]></add>    </operation>    <operation>      <search><![CDATA[$shipping_address = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>      <add position="after"><![CDATA[				$shipping_address = ($order_info['shipping_firstname']) ? $shipping_address : '';      ]]></add>    </operation>    <operation>      <search><![CDATA[$shipping_address = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>      <add position="before"><![CDATA[			foreach ($custom_fields as $custom_field) {			  if (isset($order_info['shipping_custom_field'][$custom_field['custom_field_id']])){				$format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['shipping_custom_field'][$custom_field['custom_field_id']], $format);			  }			}      ]]></add>    </operation>  </file>  <file path="catalog/controller/account/address.php">    <operation>	  <search><![CDATA[$format = '{firstname} {lastname}' . "\n" . '{company}' . "\n" . '{address_1}' . "\n" . '{address_2}' . "\n" . '{city} {postcode}' . "\n" . '{zone}' . "\n" . '{country}';]]></search>	  <add position="after" offset="1"><![CDATA[		foreach ($result['custom_field'] as $key => $custom_field) {          $format = str_replace('{custom_field_' . $key . '}', $custom_field, $format);        }	  ]]></add>	</operation>  </file>  <file path="catalog/model/checkout/order.php">    <operation>      <search><![CDATA[if ($order_info['payment_address_format']) {]]></search>      <add position="before"><![CDATA[        $this->load->model('account/custom_field');        $custom_fields = $this->model_account_custom_field->getCustomFields();      ]]></add>    </operation>    <operation>      <search><![CDATA[$data['payment_address'] = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>      <add position="before"><![CDATA[        foreach ($custom_fields as $custom_field) {          if (isset($order_info['payment_custom_field'][$custom_field['custom_field_id']])){            $format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['payment_custom_field'][$custom_field['custom_field_id']], $format);          }        }      ]]></add>    </operation>    <operation>      <search><![CDATA[$data['shipping_address'] = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>      <add position="before"><![CDATA[        foreach ($custom_fields as $custom_field) {          if (isset($order_info['payment_custom_field'][$custom_field['custom_field_id']])){            $format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['payment_custom_field'][$custom_field['custom_field_id']], $format);          }        }      ]]></add>    </operation>  </file>  <file path="catalog/controller/account/order.php">    <operation>      <search off="1"><![CDATA[$this->load->model('account/order');]]></search>      <add position="after"><![CDATA[        $this->load->model('checkout/order');      ]]></add>    </operation>    <operation>      <search offset="0"><![CDATA[$order_info = $this->model_account_order->getOrder($order_id);]]></search>      <add position="replace"><![CDATA[        $order_info = $this->model_checkout_order->getOrder($order_id);      ]]></add>    </operation>    <operation>      <search><![CDATA[if ($order_info['payment_address_format']) {]]></search>      <add position="before"><![CDATA[        $this->load->model('account/custom_field');        $custom_fields = $this->model_account_custom_field->getCustomFields();      ]]></add>    </operation>    <operation>      <search><![CDATA[$data['payment_address'] = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>      <add position="before"><![CDATA[        foreach ($custom_fields as $custom_field) {          if (isset($order_info['payment_custom_field'][$custom_field['custom_field_id']])){            if (isset($order_info['payment_custom_field'][$custom_field['custom_field_id']])) {				$format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['payment_custom_field'][$custom_field['custom_field_id']], $format);			}          }        }      ]]></add>    </operation>    <operation>      <search><![CDATA[$data['shipping_address'] = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>      <add position="before"><![CDATA[        foreach ($custom_fields as $custom_field) {          if (isset($order_info['shipping_custom_field'][$custom_field['custom_field_id']])){            $format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['shipping_custom_field'][$custom_field['custom_field_id']], $format);          }        }      ]]></add>    </operation>  </file></modification>
+<?xml version="1.0" encoding="UTF-8"?>
+<modification>
+	<name>Exibe os campos personalizados de endereço nos dados do pedido</name>
+	<code>exibir-campos-personalizados</code>
+	<version>2.2</version>
+	<author>Valdeir Psr e Manoel Vidal</author>
+	<link>http://www.opencartbrasil.com.br</link>
+
+
+
+	<file path="admin/view/template/sale/custom_field_list.tpl">
+		<operation>
+			<search><![CDATA[<td style="width: 1px;" class="text-center"><input type="checkbox" onclick="$('input[name*=\'selected\']').prop('checked', this.checked);" /></td>]]></search>
+			<add position="after"><![CDATA[									<td style="width: 1px;" class="text-center">Id</td>]]></add>
+		</operation>
+
+		<operation>
+			<search><![CDATA[<td class="text-left"><?php echo $custom_field['name']; ?></td>]]></search>
+			<add position="before"><![CDATA[<td class="text-center"><?php echo $custom_field['custom_field_id']; ?></td>]]></add>
+		</operation>
+
+		<operation>
+			<search><![CDATA[<td class="text-center" colspan="6"><?php echo $text_no_results; ?></td>]]></search>
+			<add position="replace"><![CDATA[<td class="text-center" colspan="7"><?php echo $text_no_results; ?></td>]]></add>
+		</operation>
+	</file>
+
+
+	<file path="admin/model/localisation/country.php">
+		<operation>
+			<search><![CDATA[$this->db->query("UPDATE " . DB_PREFIX . "country SET name = '" . $this->db->escape($data['name']) . "', iso_code_2 = '" . $this->db->escape($data['iso_code_2']) . "', iso_code_3 = '" . $this->db->escape($data['iso_code_3']) . "', address_format = '" . $this->db->escape($data['address_format']) . "', postcode_required = '" . (int)$data['postcode_required'] . "', status = '" . (int)$data['status'] . "' WHERE country_id = '" . (int)$country_id . "'");]]></search>
+			<add position="after"><![CDATA[		$this->db->query("UPDATE " . DB_PREFIX . "order SET shipping_address_format = '" . $this->db->escape($data['address_format']) . "', payment_address_format = '" . $this->db->escape($data['address_format']) . "'");]]></add>
+		</operation>
+	</file>
+
+
+
+	<file path="admin/controller/sale/order.php">
+		<operation>
+			<search><![CDATA[$custom_fields = $this->model_sale_custom_field->getCustomFields();]]></search>
+			<add position="replace"><![CDATA[$custom_fields = $this->model_sale_custom_field->getCustomFields(array('sort' => 'cf.sort_order'));]]></add>
+		</operation>
+
+		<operation>
+			<search><![CDATA[foreach ($orders as $order_id) {]]></search>
+			<add position="before">
+<![CDATA[
+		$this->load->model('sale/custom_field');
+		$custom_fields = $this->model_sale_custom_field->getCustomFields();
+]]>
+			</add>
+		</operation>
+
+		<operation>
+			<search><![CDATA[$payment_address = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>
+			<add position="after"><![CDATA[				$payment_address = ($order_info['payment_firstname']) ? $payment_address : '';]]></add>
+		</operation>
+
+		<operation>
+			<search><![CDATA[$payment_address = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>
+			<add position="before">
+<![CDATA[
+				foreach ($custom_fields as $custom_field) {
+					if (isset($order_info['payment_custom_field'][$custom_field['custom_field_id']])){
+						$format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['payment_custom_field'][$custom_field['custom_field_id']], $format);
+					}
+					if (isset($order_info['custom_field'][$custom_field['custom_field_id']])){
+						$format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['custom_field'][$custom_field['custom_field_id']], $format);
+					}
+				}
+]]>
+			</add>
+		</operation>
+
+		<operation>
+			<search><![CDATA[$shipping_address = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>
+			<add position="after"><![CDATA[				$shipping_address = ($order_info['shipping_firstname']) ? $shipping_address : '';]]></add>
+		</operation>
+
+		<operation>
+			<search><![CDATA[$shipping_address = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>
+			<add position="before">
+<![CDATA[
+				foreach ($custom_fields as $custom_field) {
+					if (isset($order_info['shipping_custom_field'][$custom_field['custom_field_id']])){
+						$format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['shipping_custom_field'][$custom_field['custom_field_id']], $format);
+					}
+					if (isset($order_info['custom_field'][$custom_field['custom_field_id']])){
+						$format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['custom_field'][$custom_field['custom_field_id']], $format);
+					}
+				}
+]]>
+			</add>
+		</operation>
+	</file>
+
+
+	
+	<file path="catalog/controller/account/address.php">
+		<operation>
+			<search><![CDATA[$find = array(]]></search>
+			<add position="before">
+<![CDATA[
+			foreach ($result['custom_field'] as $key => $custom_field) {
+				$format = str_replace('{custom_field_' . $key . '}', $custom_field, $format);
+			}
+]]>
+			</add>
+		</operation>
+	</file>
+
+
+
+	<file path="catalog/model/checkout/order.php">
+		<operation>
+			<search><![CDATA[if ($order_info['payment_address_format']) {]]></search>
+			<add position="before"><![CDATA[
+				$this->load->model('account/custom_field');
+				$custom_fields = $this->model_account_custom_field->getCustomFields();
+			]]></add>
+		</operation>
+
+		<operation>
+			<search><![CDATA[$data['payment_address'] = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>
+			<add position="before">
+<![CDATA[
+				foreach ($custom_fields as $custom_field) {
+					if (isset($order_info['payment_custom_field'][$custom_field['custom_field_id']])){
+						$format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['payment_custom_field'][$custom_field['custom_field_id']], $format);
+					}
+					if (isset($order_info['custom_field'][$custom_field['custom_field_id']])){
+						$format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['custom_field'][$custom_field['custom_field_id']], $format);
+					}
+				}
+]]>
+			</add>
+		</operation>
+
+		<operation>
+			<search><![CDATA[$data['shipping_address'] = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>
+			<add position="before">
+<![CDATA[
+				foreach ($custom_fields as $custom_field) {
+					if (isset($order_info['shipping_custom_field'][$custom_field['custom_field_id']])){
+						$format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['shipping_custom_field'][$custom_field['custom_field_id']], $format);
+					}
+					if (isset($order_info['custom_field'][$custom_field['custom_field_id']])){
+						$format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['custom_field'][$custom_field['custom_field_id']], $format);
+					}
+				}
+]]>
+			</add>
+		</operation>
+	</file>
+
+
+
+	<file path="catalog/controller/account/order.php">
+		<operation>
+			<search index="1"><![CDATA[$this->load->model('account/order');]]></search>
+			<add position="after"><![CDATA[		$this->load->model('checkout/order');]]></add>
+		</operation>
+
+		<operation>
+			<search index="0"><![CDATA[$order_info = $this->model_account_order->getOrder($order_id);]]></search>
+			<add position="replace"><![CDATA[$order_info = $this->model_checkout_order->getOrder($order_id);]]></add>
+		</operation>
+
+		<operation>
+			<search><![CDATA[if ($order_info['payment_address_format']) {]]></search>
+			<add position="before">
+<![CDATA[
+			$this->load->model('account/custom_field');
+			$custom_fields = $this->model_account_custom_field->getCustomFields();
+]]></add>
+		</operation>
+
+		<operation>
+			<search><![CDATA[$data['payment_address'] = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>
+			<add position="before">
+<![CDATA[
+				foreach ($custom_fields as $custom_field) {
+					if (isset($order_info['payment_custom_field'][$custom_field['custom_field_id']])) {
+						$format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['payment_custom_field'][$custom_field['custom_field_id']], $format);
+					}
+					if (isset($order_info['custom_field'][$custom_field['custom_field_id']])){
+						$format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['custom_field'][$custom_field['custom_field_id']], $format);
+					}
+				}
+]]>
+			</add>
+		</operation>
+
+		<operation>
+			<search><![CDATA[$data['shipping_address'] = str_replace(array("\r\n", "\r", "\n"), '<br />', preg_replace(array("/\s\s+/", "/\r\r+/", "/\n\n+/"), '<br />', trim(str_replace($find, $replace, $format))));]]></search>
+			<add position="before">
+<![CDATA[
+				foreach ($custom_fields as $custom_field) {
+					if (isset($order_info['shipping_custom_field'][$custom_field['custom_field_id']])){
+						$format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['shipping_custom_field'][$custom_field['custom_field_id']], $format);
+					}
+					if (isset($order_info['custom_field'][$custom_field['custom_field_id']])){
+						$format = str_replace('{custom_field_' . $custom_field['custom_field_id'] . '}', $order_info['custom_field'][$custom_field['custom_field_id']], $format);
+					}
+				}
+]]>
+			</add>
+		</operation>
+	</file>
+</modification>


### PR DESCRIPTION
Também exibir os campos personalizados do tipo `conta` além dos campos do tipo `endereço`.

Obs.: no conjunto `<file path="catalog/controller/account/order.php">` havia dois atributos `offset` na tag `search`, acredito que deveria ser o atributo `index`.